### PR TITLE
Fix the dependency reletionship between SDK/Common and openssl

### DIFF
--- a/SDK/Common/CMakeLists.txt
+++ b/SDK/Common/CMakeLists.txt
@@ -10,4 +10,4 @@ include_directories(
 
 add_library(common STATIC ${COMMON_SOURCE_FILES})
 set_target_properties(common PROPERTIES POSITION_INDEPENDENT_CODE ON)
-add_dependencies(common ${SPV_Boost_LIBRARIES})
+add_dependencies(common ${SPV_Boost_LIBRARIES} ${OpenSSL_LIBRARIES})


### PR DESCRIPTION
Add openssl (ssl and crypto) into dependency list of SDK/common target.